### PR TITLE
Use quantization for colour palettes over 64 colours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 package-lock.json
+.vite

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Inspired by [STDOOM](https://github.com/indyjo/STDOOM), RetroPass is a WebGL post-processing effect for Three.js that enables you to give your project a retro look and feel, with pixelation and colour quantisation for a nostalgic, low-res aesthetic — ideal for games or apps evoking classic video game vibes.
 
-You can choose from the default 2, 4, 16, 256, 512 and 4096 colour palettes, or create a colour palette of any any size from 2 to 4096.
+You can choose from the default 2, 4, 16, 64, 256, 512 and 4096 colour palettes, or create a custom palette of any any size from 2 to 4096 colours.
 
 [See it in action.](https://mesmotronic.github.io/three-retropass/)
 

--- a/lib/models/RetroShaderUniforms.ts
+++ b/lib/models/RetroShaderUniforms.ts
@@ -11,4 +11,7 @@ export interface RetroShaderUniforms {
   colorTexture: IUniform<THREE.DataTexture>;
   dithering: IUniform<boolean>;
   ditheringOffset: IUniform<number>;
+  quantizationEnabled: IUniform<boolean>;
+
+  [uniform: string]: THREE.IUniform<any>;
 }

--- a/lib/postprocessing/RetroPass.ts
+++ b/lib/postprocessing/RetroPass.ts
@@ -162,6 +162,22 @@ export class RetroPass extends ShaderPass {
   }
 
   /**
+   * Using quantization for larger colour palettes massively improves performance,
+   * but only supports palettes ordered as a uniform RGB cube and not custom color palettes.
+   * 
+   * If you want to use a custom color palette of 64 or more colors, you must set 
+   * this to false
+   * 
+   * @default true
+   */
+  public get quantizationEnabled(): boolean {
+    return this.uniforms.quantizationEnabled.value;
+  }
+  public set quantizationEnabled(value: boolean) {
+    this.uniforms.quantizationEnabled.value = value;
+  }
+
+  /**
    * Set the pixel resolution to use (used by EffectComposer)
    * @see {@link RetroPass.resolution}
    */

--- a/lib/postprocessing/RetroPass.ts
+++ b/lib/postprocessing/RetroPass.ts
@@ -165,8 +165,7 @@ export class RetroPass extends ShaderPass {
    * Using quantization for larger colour palettes massively improves performance,
    * but only supports palettes ordered as a uniform RGB cube and not custom color palettes.
    * 
-   * If you want to use a custom color palette of 64 or more colors, you must set 
-   * this to false
+   * If you want to use a custom color palette over 64 colors, you must set this to false
    * 
    * @default true
    */

--- a/lib/shaders/RetroShader.ts
+++ b/lib/shaders/RetroShader.ts
@@ -53,7 +53,18 @@ export const RetroShader: {
       vec3 higher = 1.055 * pow(linearColor, vec3(1.0/2.4)) - 0.055;
       return mix(lower, higher, cutoff);
     }
-    
+
+    // Quantize color to palette index for N colors (N = 2..4096)
+    int quantizeToPaletteIndex(vec3 c, int colorCount) {
+      // Find the number of steps per channel
+      int steps = int(pow(float(colorCount), 1.0/3.0) + 0.5);
+      steps = max(1, steps);
+      int r = int(clamp(floor(c.r * float(steps - 1) + 0.5), 0.0, float(steps - 1)));
+      int g = int(clamp(floor(c.g * float(steps - 1) + 0.5), 0.0, float(steps - 1)));
+      int b = int(clamp(floor(c.b * float(steps - 1) + 0.5), 0.0, float(steps - 1)));
+      return r * steps * steps + g * steps + b;
+    }
+
     void main() {
       // Compute retro UV for pixelation
       vec2 retroUV = (floor(vUv * resolution) + 0.5) / resolution;
@@ -75,19 +86,25 @@ export const RetroShader: {
         c = clamp(c, 0.0, 1.0);
       }
 
-      // Find closest color in palette
       vec3 closestColor = vec3(0.0);
-      float minDist = 1e6;
-      for (int i = 0; i < colorCount; i++) {
-        vec3 paletteColor = texture2D(colorTexture, vec2((float(i) + 0.5) / float(colorCount), 0.5)).rgb;
-        float dist = distance(c, paletteColor);
-        if (dist < minDist) {
-          minDist = dist;
-          closestColor = paletteColor;
+
+      // Use brute-force search for small palettes, quantize for large
+      if (colorCount <= 64) {
+        float minDist = 1e6;
+        for (int i = 0; i < colorCount; i++) {
+          vec3 paletteColor = texture2D(colorTexture, vec2((float(i) + 0.5) / float(colorCount), 0.5)).rgb;
+          float dist = distance(c, paletteColor);
+          if (dist < minDist) {
+            minDist = dist;
+            closestColor = paletteColor;
+          }
         }
+      } else {
+        int idx = quantizeToPaletteIndex(c, colorCount);
+        float paletteIndex = (float(idx) + 0.5) / float(colorCount);
+        closestColor = texture2D(colorTexture, vec2(paletteIndex, 0.5)).rgb;
       }
 
-      // gl_FragColor = vec4(closestColor, 1.0);
       gl_FragColor = vec4(linearToSrgb(closestColor), 1.0);
     }
   `,

--- a/lib/shaders/RetroShader.ts
+++ b/lib/shaders/RetroShader.ts
@@ -91,7 +91,7 @@ export const RetroShader: RetroShaderParameters = {
       vec3 closestColor = vec3(0.0);
 
       // By default we use brute-force for small palettes, quantize for large
-      if (quantizationEnabled == false || colorCount < 64) {
+      if (quantizationEnabled == false || colorCount <= 64) {
         float minDist = 1e6;
         for (int i = 0; i < colorCount; i++) {
           vec3 paletteColor = texture2D(colorTexture, vec2((float(i) + 0.5) / float(colorCount), 0.5)).rgb;

--- a/lib/shaders/RetroShader.ts
+++ b/lib/shaders/RetroShader.ts
@@ -3,14 +3,14 @@ import { RetroShaderUniforms } from "../models/RetroShaderUniforms";
 import { createColorTexture } from "../utils/createColorTexture";
 import { createColorPalette } from "../utils/createColorPalette";
 
+interface RetroShaderParameters extends THREE.ShaderMaterialParameters {
+  uniforms: RetroShaderUniforms;
+}
+
 /**
  * Shader that creates retro-style post-processing effect
  */
-export const RetroShader: {
-  uniforms: RetroShaderUniforms;
-  vertexShader: string;
-  fragmentShader: string;
-} = {
+export const RetroShader: RetroShaderParameters = {
   uniforms: {
     tDiffuse: { value: null },
     resolution: { value: new THREE.Vector2(320, 200) },
@@ -18,6 +18,7 @@ export const RetroShader: {
     colorTexture: { value: createColorTexture(createColorPalette(16)) },
     dithering: { value: true },
     ditheringOffset: { value: 0.2 },
+    quantizationEnabled: { value: true },
   },
 
   vertexShader: /* glsl */ `
@@ -35,6 +36,7 @@ export const RetroShader: {
     uniform sampler2D colorTexture;
     uniform bool dithering;
     uniform float ditheringOffset;
+    uniform bool quantizationEnabled;
 
     varying vec2 vUv;
 
@@ -88,8 +90,8 @@ export const RetroShader: {
 
       vec3 closestColor = vec3(0.0);
 
-      // Use brute-force search for small palettes, quantize for large
-      if (colorCount <= 64) {
+      // By default we use brute-force for small palettes, quantize for large
+      if (quantizationEnabled == false || colorCount < 64) {
         float minDist = 1e6;
         for (int i = 0; i < colorCount; i++) {
           vec3 paletteColor = texture2D(colorTexture, vec2((float(i) + 0.5) / float(colorCount), 0.5)).rgb;

--- a/lib/utils/createColorPalette.ts
+++ b/lib/utils/createColorPalette.ts
@@ -1,6 +1,18 @@
 import * as THREE from 'three';
 import { ColorCount } from '../models/ColorCount';
 
+export function createQuantizedColorPalette(size: number): THREE.Color[] {
+  const palette: THREE.Color[] = [];
+  for (let r = 0; r < size; r++) {
+    for (let g = 0; g < size; g++) {
+      for (let b = 0; b < size; b++) {
+        palette.push(new THREE.Color(r / (size - 1), g / (size - 1), b / (size - 1)));
+      }
+    }
+  }
+  return palette;
+}
+
 /**
  * Creates a color palette based on the specified color count
  */
@@ -10,44 +22,19 @@ export function createColorPalette(colorCount: ColorCount): THREE.Color[] {
   switch (true) {
     // 4096 colours - Full Atari STE / Amiga color palette
     case colorCount > 512: {
-      const palette: THREE.Color[] = [];
-      for (let r = 0; r < 16; r++) {
-        for (let g = 0; g < 16; g++) {
-          for (let b = 0; b < 16; b++) {
-            palette.push(new THREE.Color(r / 15, g / 15, b / 15));
-          }
-        }
-      }
-      colorPalette = palette;
+      colorPalette = createQuantizedColorPalette(16);
       break;
     }
 
     // 512 colours - Full Atari ST (before E) color palette
     case colorCount > 256: {
-      const palette: THREE.Color[] = [];
-      for (let r = 0; r < 8; r++) {
-        for (let g = 0; g < 8; g++) {
-          for (let b = 0; b < 8; b++) {
-            palette.push(new THREE.Color(r / 7, g / 7, b / 7));
-          }
-        }
-      }
-      colorPalette = palette;
+      colorPalette = createQuantizedColorPalette(8);
       break;
     }
 
     // 256 colours - Web safe colours plus grayscale
     case colorCount > 64: {
-      const palette: THREE.Color[] = [];
-      // Web safe colours
-      for (let r = 0; r < 6; r++) {
-        for (let g = 0; g < 6; g++) {
-          for (let b = 0; b < 6; b++) {
-            palette.push(new THREE.Color(r / 5, g / 5, b / 5));
-          }
-        }
-      }
-      // ... plus grayscale
+      const palette = createQuantizedColorPalette(6);
       while (palette.length < 256) {
         const v = (palette.length - 216) / 39.0;
         palette.push(new THREE.Color(v, v, v));
@@ -58,15 +45,7 @@ export function createColorPalette(colorCount: ColorCount): THREE.Color[] {
 
     // 64 colours - Web safe colours plus grayscale
     case colorCount > 16: {
-      const palette: THREE.Color[] = [];
-      for (let r = 0; r < 4; r++) {
-        for (let g = 0; g < 4; g++) {
-          for (let b = 0; b < 4; b++) {
-            palette.push(new THREE.Color(r / 3, g / 3, b / 3));
-          }
-        }
-      }
-      colorPalette = palette;
+      colorPalette = createQuantizedColorPalette(4);
       break;
     }
 

--- a/lib/utils/createColorPalette.ts
+++ b/lib/utils/createColorPalette.ts
@@ -37,8 +37,9 @@ export function createColorPalette(colorCount: ColorCount): THREE.Color[] {
     }
 
     // 256 colours - Web safe colours plus grayscale
-    case colorCount > 16: {
+    case colorCount > 64: {
       const palette: THREE.Color[] = [];
+      // Web safe colours
       for (let r = 0; r < 6; r++) {
         for (let g = 0; g < 6; g++) {
           for (let b = 0; b < 6; b++) {
@@ -46,10 +47,24 @@ export function createColorPalette(colorCount: ColorCount): THREE.Color[] {
           }
         }
       }
-      // Grayscale
+      // ... plus grayscale
       while (palette.length < 256) {
         const v = (palette.length - 216) / 39.0;
         palette.push(new THREE.Color(v, v, v));
+      }
+      colorPalette = palette;
+      break;
+    }
+
+    // 64 colours - Web safe colours plus grayscale
+    case colorCount > 16: {
+      const palette: THREE.Color[] = [];
+      for (let r = 0; r < 4; r++) {
+        for (let g = 0; g < 4; g++) {
+          for (let b = 0; b < 4; b++) {
+            palette.push(new THREE.Color(r / 3, g / 3, b / 3));
+          }
+        }
       }
       colorPalette = palette;
       break;

--- a/lib/utils/createColorPalette.ts
+++ b/lib/utils/createColorPalette.ts
@@ -36,22 +36,22 @@ export function createColorPalette(colorCount: ColorCount): THREE.Color[] {
       break;
     }
 
-    // 256 colours - Web safe palette plus grayscale
+    // 256 colours - Web safe colours plus grayscale
     case colorCount > 16: {
       const palette: THREE.Color[] = [];
-      const steps = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0];
-      for (let r of steps) {
-        for (let g of steps) {
-          for (let b of steps) {
-            palette.push(new THREE.Color(r, g, b));
+      for (let r = 0; r < 6; r++) {
+        for (let g = 0; g < 6; g++) {
+          for (let b = 0; b < 6; b++) {
+            palette.push(new THREE.Color(r / 5, g / 5, b / 5));
           }
         }
       }
-      for (let i = 0; i < 40; i++) {
-        const v = i / 39.0;
+      // Grayscale
+      while (palette.length < 256) {
+        const v = (palette.length - 216) / 39.0;
         palette.push(new THREE.Color(v, v, v));
       }
-      colorPalette = palette.slice(0, 256);
+      colorPalette = palette;
       break;
     }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Neil Rackett",
   "license": "BSD-2-Clause",
   "description": "RetroPass applies a retro aesthetic to your Three.js project, emulating the visual style of classic 8-bit and 16-bit games",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,6 +130,7 @@ const palettes: { [key: string]: THREE.Color[] | null; } = {
     new THREE.Color(0.333, 0.0, 0.666), // Purple
     new THREE.Color(0.0, 0.666, 0.333), // Teal
   ],
+  Random256: Array.from({ length: 256 }, (i: number) => new THREE.Color(i / 256, Math.random(), 0)),
 };
 retroFolder.add({ colorPalette: 'Default' }, 'colorPalette', Object.keys(palettes)).name('Color Palette').onChange((value: string) => {
   retroPass.colorPalette = palettes[value] ?? createColorPalette(retroPass.colorCount);

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,8 +35,8 @@ for (let i = 0; i < 16; i++) {
     });
     const sphere = new THREE.Mesh(geometry, material);
     sphere.position.set(
-      (i - 8) * 1.25,
-      (j - 8) * 1.25,
+      (i - 7.5) * 1.25,
+      (j - 7.5) * 1.25,
       0
     );
     spheres.push(sphere);
@@ -90,7 +90,7 @@ const retroFolder = gui.addFolder('RetroPass Parameters');
 retroFolder.add({ enabled: retroPass.enabled }, 'enabled').name('Enabled').onChange((value: boolean) => {
   retroPass.enabled = value;
 });
-retroFolder.add({ colorCount: retroPass.colorCount }, 'colorCount', [2, 4, 16, 256, 512, 4096]).name('Color Count').onChange((value: number) => {
+retroFolder.add({ colorCount: retroPass.colorCount }, 'colorCount', [2, 4, 16, 64, 256, 512, 4096]).name('Color Count').onChange((value: number) => {
   retroPass.colorCount = value;
 });
 retroFolder.add(retroPass, 'dithering').name('Dithering');
@@ -130,7 +130,6 @@ const palettes: { [key: string]: THREE.Color[] | null; } = {
     new THREE.Color(0.333, 0.0, 0.666), // Purple
     new THREE.Color(0.0, 0.666, 0.333), // Teal
   ],
-  Random256: Array.from({ length: 256 }, (i: number) => new THREE.Color(i / 256, Math.random(), 0)),
 };
 retroFolder.add({ colorPalette: 'Default' }, 'colorPalette', Object.keys(palettes)).name('Color Palette').onChange((value: string) => {
   retroPass.colorPalette = palettes[value] ?? createColorPalette(retroPass.colorCount);


### PR DESCRIPTION
By default, RetroPass uses quantization for palettes over 64 colours, i.e. it expects the palette to be constructed as if it forms a perfect RGB cube

This massively improves performance, but doesn't support arbitrary palettes, so you can switch it off by setting `quantizationEnabled` to `false` if you need to